### PR TITLE
Change naming conventions on income statement

### DIFF
--- a/src/components/basicGraph.js
+++ b/src/components/basicGraph.js
@@ -138,13 +138,13 @@ export const BasicGraph = ({ data, setActive, setPayload, setLabel }) => {
             content={<CustomTooltip setActive={setActive} setPayload={setPayload} setLabel={setLabel} />}
             cursor={{ strokeDasharray: '3 3' }}
           />
-          <Bar dataKey="monthlyRevenue" name='Net Monthly Revenue' barSize={20} fill={graphColors.monthlyRevenue} yAxisId='right' />
-          <Bar dataKey="netMonthlyProfit" name='Net Monthly Profit' barSize={20} fill={graphColors.netMonthlyProfit} yAxisId='right' />
+          <Bar dataKey="monthlyRevenue" name='Monthly Revenue' barSize={20} fill={graphColors.monthlyRevenue} yAxisId='right' />
+          <Bar dataKey="netMonthlyProfit" name='Gross Monthly Profit' barSize={20} fill={graphColors.netMonthlyProfit} yAxisId='right' />
           <Line type="monotone" dataKey="hwValue" name='Hardware Value' stroke={graphColors.hardware} fill={graphColors.hardware} strokeWidth={3} dot={null} />
-          <Line type="monotone" dataKey="cashflow" name='Free Cashflow' stroke={graphColors.cashflow} fill={graphColors.cashflow} strokeWidth={3} dot={null} />
+          <Line type="monotone" dataKey="cashflow" name='Cash Position' stroke={graphColors.cashflow} fill={graphColors.cashflow} strokeWidth={3} dot={null} />
           <Line type="monotone" dataKey="netPosition" name='Net Position' stroke={graphColors.netPosition} fill={graphColors.netPosition} strokeWidth={3} dot={null} />
-          <Line type="monotone" dataKey="netProfitCumulative" name='Cumulative Net Profit' stroke={graphColors.netProfitCumulative} fill={graphColors.netProfitCumulative} strokeWidth={3} dot={null} />
-          <Line type="monotone" dataKey="grossProfitCumulative" name='Cumulative Gross Profit' stroke={graphColors.grossProfitCumulative} fill={graphColors.grossProfitCumulative} strokeWidth={3} dot={null} />
+          <Line type="monotone" dataKey="netProfitCumulative" name='Cumulative Gross Profit' stroke={graphColors.netProfitCumulative} fill={graphColors.netProfitCumulative} strokeWidth={3} dot={null} />
+          <Line type="monotone" dataKey="grossProfitCumulative" name='Cumulative Net Profit' stroke={graphColors.grossProfitCumulative} fill={graphColors.grossProfitCumulative} strokeWidth={3} dot={null} />
           <ReferenceLine y={breakeven} stroke={graphColors.breakeven} strokeWidth={2} strokeDasharray="4 4">
             <Label fill={graphColors.breakeven} position='top' content={CustomLabel}></Label>
           </ReferenceLine>

--- a/src/components/basicGraph.js
+++ b/src/components/basicGraph.js
@@ -20,10 +20,10 @@ const graphColors = {
   hardware: '#07535F',
   netPosition: '#2F8F9E',
   breakeven: '#7D443C',
-  netMonthlyProfit: '#638269',
+  grossMonthlyProfit: '#638269',
   monthlyRevenue: '#FAF4D4',
-  netProfitCumulative: '#777696',
-  grossProfitCumulative: '#CD5C5C',
+  grossProfitCumulative: '#777696',
+  netProfitCumulative: '#CD5C5C',
 }
 
 const renderCusomLegend = (props) => {
@@ -139,12 +139,12 @@ export const BasicGraph = ({ data, setActive, setPayload, setLabel }) => {
             cursor={{ strokeDasharray: '3 3' }}
           />
           <Bar dataKey="monthlyRevenue" name='Monthly Revenue' barSize={20} fill={graphColors.monthlyRevenue} yAxisId='right' />
-          <Bar dataKey="netMonthlyProfit" name='Gross Monthly Profit' barSize={20} fill={graphColors.netMonthlyProfit} yAxisId='right' />
+          <Bar dataKey="grossMonthlyProfit" name='Gross Monthly Profit' barSize={20} fill={graphColors.grossMonthlyProfit} yAxisId='right' />
           <Line type="monotone" dataKey="hwValue" name='Hardware Value' stroke={graphColors.hardware} fill={graphColors.hardware} strokeWidth={3} dot={null} />
           <Line type="monotone" dataKey="cashflow" name='Cash Position' stroke={graphColors.cashflow} fill={graphColors.cashflow} strokeWidth={3} dot={null} />
           <Line type="monotone" dataKey="netPosition" name='Net Position' stroke={graphColors.netPosition} fill={graphColors.netPosition} strokeWidth={3} dot={null} />
-          <Line type="monotone" dataKey="netProfitCumulative" name='Cumulative Gross Profit' stroke={graphColors.netProfitCumulative} fill={graphColors.netProfitCumulative} strokeWidth={3} dot={null} />
-          <Line type="monotone" dataKey="grossProfitCumulative" name='Cumulative Net Profit' stroke={graphColors.grossProfitCumulative} fill={graphColors.grossProfitCumulative} strokeWidth={3} dot={null} />
+          <Line type="monotone" dataKey="grossProfitCumulative" name='Cumulative Gross Profit' stroke={graphColors.grossProfitCumulative} fill={graphColors.grossProfitCumulative} strokeWidth={3} dot={null} />
+          <Line type="monotone" dataKey="netProfitCumulative" name='Cumulative Net Profit' stroke={graphColors.netProfitCumulative} fill={graphColors.netProfitCumulative} strokeWidth={3} dot={null} />
           <ReferenceLine y={breakeven} stroke={graphColors.breakeven} strokeWidth={2} strokeDasharray="4 4">
             <Label fill={graphColors.breakeven} position='top' content={CustomLabel}></Label>
           </ReferenceLine>

--- a/src/services/crunchNumbers.js
+++ b/src/services/crunchNumbers.js
@@ -102,17 +102,17 @@ const createDataSet = ({ values = initialValues, height }) => {
     const monthlyOpexSats = parsedValues.opex / exchangeRate * constants.satsPerBtc
     const monthlyExpensesSats = monthlyPowerExpenseSats + monthlyFeesSats + monthlyOpexSats
     runningCostDollars += ((monthlyExpensesSats / constants.satsPerBtc) * exchangeRate)
-    const netProfitSats = monthlyRevenueSats - monthlyExpensesSats
-    runningPL += netProfitSats
+    const grossProfitSats = monthlyRevenueSats - monthlyExpensesSats
+    runningPL += grossProfitSats
 
     // Power Cost Breakeven Calculation
-    if (netProfitSats === 0 && netProfitSats < lowestMonthProfit) {
-      lowestMonthProfit = netProfitSats
+    if (grossProfitSats === 0 && grossProfitSats < lowestMonthProfit) {
+      lowestMonthProfit = grossProfitSats
       breakevenElectricity = parsedValues.powerCostPerKwh
     }
-    if (lowestMonthProfit === 0 || netProfitSats < lowestMonthProfit) {
-      lowestMonthProfit = netProfitSats
-      const breakevenMonthlyPowerExpenses = monthlyPowerExpenseSats + netProfitSats
+    if (lowestMonthProfit === 0 || grossProfitSats < lowestMonthProfit) {
+      lowestMonthProfit = grossProfitSats
+      const breakevenMonthlyPowerExpenses = monthlyPowerExpenseSats + grossProfitSats
       breakevenElectricity = breakevenMonthlyPowerExpenses / constants.satsPerBtc * exchangeRate / constants.daysPerMonth / 24 / hourlyPowerDraw
     }
 
@@ -121,8 +121,8 @@ const createDataSet = ({ values = initialValues, height }) => {
       breakevenMonth = i + 1
     }
 
-    d.netProfitCumulative = runningPL
-    d.grossProfitCumulative = runningPL - cumulativeDepreciationSats
+    d.grossProfitCumulative = runningPL
+    d.netProfitCumulative = runningPL - cumulativeDepreciationSats
     // Line charts
     d.hwValue = hwValueSats
     d.cashflow = runningPL + startUpPositionSats
@@ -130,7 +130,7 @@ const createDataSet = ({ values = initialValues, height }) => {
     d.breakeven = parsedValues.capex
     // Bar charts
     d.monthlyRevenue = monthlyRevenueSats
-    d.netMonthlyProfit = netProfitSats
+    d.grossMonthlyProfit = grossProfitSats
   })
 
   if (breakevenMonth === 0 && runningPL > 0) {


### PR DESCRIPTION
- Gross and Net were mixed up
- Cashflow renamed to Cash Position for clarity

Old: <img width="462" alt="Screen Shot 2023-03-04 at 2 01 53 PM" src="https://user-images.githubusercontent.com/104955699/224835626-d6f04c4e-466d-474e-8149-9f9426b961e9.png">

New: 
<img width="444" alt="Screen Shot 2023-03-04 at 2 02 06 PM" src="https://user-images.githubusercontent.com/104955699/224835674-fe1da63c-5f87-441f-b05c-2180b803f171.png">
